### PR TITLE
Update and clean up gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ if (project.hasProperty("buildNo")) version += ".$buildNo"
 
 java {
     setSourceCompatibility(1.8)
-    setTargetCompatibility(1.8)
     withSourcesJar()
     withJavadocJar()
 }
@@ -35,8 +34,6 @@ publishing {
     publications {
         gpr(MavenPublication) {
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,60 +1,36 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 plugins {
     id 'java'
     id 'idea'
     id "maven-publish"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'com.jarnoharno.github-packages'
 }
-
-apply plugin: "kotlin"
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 if (project.hasProperty("buildNo")) version += ".$buildNo"
 
+java {
+    setSourceCompatibility(1.8)
+    setTargetCompatibility(1.8)
+    withSourcesJar()
+    withJavadocJar()
+}
+
+githubPackages {
+    username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+    accessToken = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+}
+
 repositories {
     mavenCentral()
-    maven {
-        name = 'spigotmc-repo'
-        url = 'https://hub.spigotmc.org/nexus/content/groups/public/'
-    }
-    maven {
-        name = 'sonatype'
-        url = 'https://oss.sonatype.org/content/groups/public/'
-    }
-    maven {
-        name = 'dre-repo'
-        url = 'https://erethon.de/repo/'
-    }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    getArchiveClassifier().set('sources')
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    getArchiveClassifier().set('javadoc')
-    from javadoc.destinationDir
+    maven { url 'https://hub.spigotmc.org/nexus/content/groups/public/' }
+    maven { url 'https://oss.sonatype.org/content/groups/public/' }
+    maven { url 'https://erethon.de/repo/' }
 }
 
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/MineInAbyss/guiy")
-            credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-            }
+            maven githubPackages("MineInAbyss/guiy")
         }
     }
     publications {
@@ -67,22 +43,22 @@ publishing {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    implementation 'de.erethon:headlib:3.0.2'
     compileOnly 'org.spigotmc:spigot-api:1.15-R0.1-SNAPSHOT'
-    implementation 'com.google.protobuf:protobuf-java:3.8.0'
-    implementation 'com.google.dagger:dagger:2.+'
-    compileOnly 'org.jetbrains:annotations:17.0.0'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.+'
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compileOnly 'org.jetbrains:annotations:17.0.0'
+    implementation 'de.erethon:headlib:3.0.2'
+    implementation 'com.google.protobuf:protobuf-java:3.8.0'
+    implementation 'com.google.dagger:dagger:2.28.1'
+
+    testImplementation 'junit:junit:4.12'
+
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.28.1'
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens
 
 processResources {
-    from(sourceSets.main.resources.srcDirs) {
-        filter ReplaceTokens, tokens: [version: version]
-    }
+    filter ReplaceTokens, tokens: [version: version]
 }
 
 compileKotlin { kotlinOptions { jvmTarget = "1.8" } }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'idea'
     id "maven-publish"
     id 'org.jetbrains.kotlin.jvm'
-    id 'com.jarnoharno.github-packages'
 }
 
 if (project.hasProperty("buildNo")) version += ".$buildNo"
@@ -15,12 +14,6 @@ java {
     withJavadocJar()
 }
 
-githubPackages {
-    repository = "MineInAbyss/guiy"
-    username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-    accessToken = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-}
-
 repositories {
     mavenCentral()
     maven { url 'https://hub.spigotmc.org/nexus/content/groups/public/' }
@@ -30,7 +23,14 @@ repositories {
 
 publishing {
     repositories {
-        maven githubPackages()
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/MineInAbyss/guiy")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
     publications {
         gpr(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ java {
 }
 
 githubPackages {
+    repository = "MineInAbyss/guiy"
     username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
     accessToken = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
 }
@@ -29,7 +30,7 @@ repositories {
 
 publishing {
     repositories {
-        maven githubPackages("MineInAbyss/guiy")
+        maven githubPackages()
     }
     publications {
         gpr(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,7 @@ repositories {
 
 publishing {
     repositories {
-        maven {
-            maven githubPackages("MineInAbyss/guiy")
-        }
+        maven githubPackages("MineInAbyss/guiy")
     }
     publications {
         gpr(MavenPublication) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.derongan.minecraft
 version=0.1.0-alpha
-kotlin_version=1.3.70
+kotlin_version=1.3.72

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement{
     plugins {
         id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
-        id 'com.jarnoharno.github-packages' version '1.0.0'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement{
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
+        id 'com.jarnoharno.github-packages' version '1.0.0'
+    }
+}
+
+rootProject.name = 'guiy'


### PR DESCRIPTION
Some changes I've made to clean the script up, which we'll probably use for other plugins as well.

- Switch everything to plugins block (no more buildscript)
    - This means settings.gradle defines plugin version with the pluginManagment block
- ~~Use a nice little plugin for github packages, this is used for the publish (can also be used for adding the repositories in one line)~~ Plugin doesn't work nicely with actions, I've made [my own](https://github.com/0ffz/gpr-for-gradle) but it only works for kotlin gradle, it should be possible to make it work with groovy but I havent figured it out yet.
- Use java block to make sources and javadoc jar tasks
- Do not specify name for maven repos (this is how they do it in all the big projects I've looked at)
- Process resources task is apparently already limited to the resources, so removed the explicit "from" block

Things I'd still like to decide on:
- Toggling composite builds on and off
- Whether or not to use the gradle kotlin DSL
- Moving our own repetitive tasks and the like into a gradle plugin + and how to make kotlin's extension functions work with groovy if we decide to stick with groovy.